### PR TITLE
#167733663  Enable User to delete Comments made a on Travel Request

### DIFF
--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -2,7 +2,7 @@ import { CommentService } from '../services';
 import { Helpers } from '../utils';
 
 const { errorResponse, successResponse } = Helpers;
-const { createComment } = CommentService;
+const { createComment, deleteCommentById } = CommentService;
 
 
 /**
@@ -26,6 +26,26 @@ export default class CommentController {
       body.userId = id;
       const comment = await createComment(body);
       successResponse(res, comment, 201);
+    } catch (err) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * Deletes a comment on a travel request.
+   *
+   * @static
+   * @param {Request} req - The request from the endpoint.
+   * @param {Response} res - The response returned by the method.
+   * @returns { JSON } A JSON response containing with an empty data object.
+   * @memberof CommentController
+   */
+  static async deleteComment(req, res) {
+    try {
+      const commentId = parseInt(req.params.commentId, 10);
+      const rowDeleted = await deleteCommentById(commentId);
+      if (!rowDeleted) return errorResponse(res, {});
+      successResponse(res, { id: commentId }, 200);
     } catch (err) {
       errorResponse(res, {});
     }

--- a/src/database/migrations/20190915234032-alter-request-managerId-non-null-constraint.js
+++ b/src/database/migrations/20190915234032-alter-request-managerId-non-null-constraint.js
@@ -1,0 +1,27 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => (
+    queryInterface.changeColumn('Requests', 'managerId',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          key: 'id',
+          model: 'Users'
+        }
+      })),
+
+  down: (queryInterface, Sequelize) => (
+    queryInterface.changeColumn('Requests', 'managerId',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          key: 'id',
+          model: 'Users'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      })
+  )
+};

--- a/src/index.js
+++ b/src/index.js
@@ -80,10 +80,6 @@ app.use((err, req, res, next) => {
     }
   });
 });
-// routes
-app.use(routes);
-app.get('/', (req, res) => res.status(200).send({ message: 'welcome to BN: jubilee-team' }));
-app.all('*', (req, res) => res.send({ message: 'route not found' }));
 
 // finally, let's start our server...
 const server = app.listen(process.env.PORT || 3000, () => {

--- a/src/routes/comment.js
+++ b/src/routes/comment.js
@@ -3,11 +3,12 @@ import { AuthMiddleware, CommentMiddleware } from '../middlewares';
 import { CommentController } from '../controllers';
 
 const { authenticate } = AuthMiddleware;
-const { validateComment, verifyAuthor } = CommentMiddleware;
-const { create } = CommentController;
+const { validateComment, verifyAuthor, verifyCommenter } = CommentMiddleware;
+const { create, deleteComment } = CommentController;
 
 const router = Router();
 
 router.post('/', authenticate, verifyAuthor, validateComment, create);
+router.delete('/:commentId', authenticate, verifyCommenter, deleteComment);
 
 export default router;

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -9,7 +9,7 @@ const { Comment, sequelize } = db;
  */
 export default class CommentService {
   /**
-   * Fetches a commen instance based on it's primary key.
+   * Fetches a comment instance based on it's primary key.
    * @static
    * @param {integer} commentId - Primary key of the comment to be fetched.
    * @param {object} options - Additional query information
@@ -22,7 +22,7 @@ export default class CommentService {
 
 
   /**
-   * Creates a facility record in the database.
+   * Creates a comment record in the database.
    * @static
    * @param {object} commentData - comment data to be recorded in the database.
    * @returns {Promise<object>} - A promise object which resolves to the newly created comment.
@@ -43,5 +43,16 @@ export default class CommentService {
     } catch (err) {
       throw new ApiError(500, 'comment was not created');
     }
+  }
+
+  /**
+   * Deletes a comment record from the database.
+   * @static
+   * @param {number} commentId - id of comment to be deleted from the database.
+   * @returns {Promise<object>} - A promise object which resolves to the newly created comment.
+   * @memberof CommentService
+   */
+  static async deleteCommentById(commentId) {
+    return Comment.destroy({ where: { id: commentId } });
   }
 }

--- a/src/test/comment.test.js
+++ b/src/test/comment.test.js
@@ -19,7 +19,7 @@ chai.use(chaiHttp);
 chai.use(sinonChai);
 
 describe('Comment route endpoints', () => {
-  let user, wrongUserToken, commentObj;
+  let user, wrongUserToken, commentObj, commentId;
   before(async () => {
     const companyReq = { body: { ...newCompany, email: 'daylay1t@hotmail.com' } };
     const { data: { signupToken, admin } } = await companySignUp(companyReq, mockResponse);
@@ -38,70 +38,128 @@ describe('Comment route endpoints', () => {
   afterEach(() => {
     sinon.restore();
   });
-  it('should successfully create a comment', async () => {
-    const response = await chai
-      .request(server)
-      .post('/api/comment')
-      .send(commentObj).set('Cookie', `token=${user.token}`);
-    expect(response).to.have.status(201);
-    expect(response.body.data).to.include.all.keys('id', 'createdAt', 'author');
-    expect(response.body.data).to.include({ message: commentObj.message });
+  describe('POST /comment', () => {
+    it('should successfully create a comment', async () => {
+      const response = await chai
+        .request(server)
+        .post('/api/comment')
+        .send(commentObj).set('Cookie', `token=${user.token}`);
+      expect(response).to.have.status(201);
+      expect(response.body.data).to.include.all.keys('id', 'createdAt', 'author');
+      expect(response.body.data).to.include({ message: commentObj.message });
+      const { data: { id } } = response.body;
+      commentId = id;
+    });
+    it('should prevent a comment from being created with invalid entries', async () => {
+      const response = await chai
+        .request(server)
+        .post('/api/comment')
+        .send({ ...commentObj, message: '' }).set('Cookie', `token=${user.token}`);
+      expect(response).to.have.status(400);
+      expect(response.body.error).to.be.a('object');
+      expect(response.body.error.message).to
+        .eql('Please enter a valid comment and ensure it is not more than 1500 characters long');
+    });
+    it('should prevent a comment from being created if the message field is missing', async () => {
+      delete commentObj.message;
+      const response = await chai
+        .request(server)
+        .post('/api/comment')
+        .send(commentObj).set('Cookie', `token=${user.token}`);
+      expect(response).to.have.status(400);
+      expect(response.body.error).to.be.a('object');
+      expect(response.body.error.message).to.be.eql('Please enter a valid comment and ensure it is not more than 1500 characters long');
+    });
+    it('should prevent an unautheticated user from creating a comment', async () => {
+      const response = await chai
+        .request(server)
+        .post('/api/comment')
+        .send(commentObj);
+      expect(response).to.have.status(401);
+      expect(response.body.error.message).to.be.eql('Access denied, Token required');
+    });
+    it('should prevent an unauthorized user from creating a comment', async () => {
+      const response = await chai
+        .request(server)
+        .post('/api/comment')
+        .send(commentObj).set('Cookie', `token=${wrongUserToken}`);
+      expect(response).to.have.status(403);
+      expect(response.body.error.message).to.eql('You are an unauthorized author');
+    });
+    it('should return a 500 error response if something goes wrong while creating the comment', async () => {
+      const req = { data: { id: 1 } };
+      const mock = () => {
+        const res = {};
+        res.status = sinon.stub().returns(res);
+        res.json = sinon.stub().returns(res);
+        return res;
+      };
+      const res = mock();
+      const errorResponse = {
+        status: 'fail',
+        error: {
+          message: 'Some error occurred while processing your Request',
+          errors: undefined
+        }
+      };
+      sinon.stub(CommentService, 'createComment').throws();
+      await CommentController.create(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+      expect(res.json).to.have.been.calledWith(errorResponse);
+    });
   });
-  it('should prevent a comment from being created with invalid entries', async () => {
-    const response = await chai
-      .request(server)
-      .post('/api/comment')
-      .send({ ...commentObj, message: '' }).set('Cookie', `token=${user.token}`);
-    expect(response).to.have.status(400);
-    expect(response.body.error).to.be.a('object');
-    expect(response.body.error.message).to
-      .eql('Please enter a valid comment and ensure it is not more than 1500 characters long');
-  });
-  it('should prevent a comment from being created if the message field is missing', async () => {
-    delete commentObj.message;
-    const response = await chai
-      .request(server)
-      .post('/api/comment')
-      .send(commentObj).set('Cookie', `token=${user.token}`);
-    expect(response).to.have.status(400);
-    expect(response.body.error).to.be.a('object');
-    expect(response.body.error.message).to.be.eql('Please enter a valid comment and ensure it is not more than 1500 characters long');
-  });
-  it('should prevent an unautheticated user from creating a comment', async () => {
-    const response = await chai
-      .request(server)
-      .post('/api/comment')
-      .send(commentObj);
-    expect(response).to.have.status(401);
-    expect(response.body.error.message).to.be.eql('Access denied, Token required');
-  });
-  it('should prevent an unauthorized user from creating a comment', async () => {
-    const response = await chai
-      .request(server)
-      .post('/api/comment')
-      .send(commentObj).set('Cookie', `token=${wrongUserToken}`);
-    expect(response).to.have.status(403);
-    expect(response.body.error.message).to.eql('You are an unauthorized author');
-  });
-  it('should return a 500 error response if something goes wrong while creating the comment', async () => {
-    const req = { data: { id: 1 } };
-    const mock = () => {
-      const res = {};
-      res.status = sinon.stub().returns(res);
-      res.json = sinon.stub().returns(res);
-      return res;
-    };
-    const res = mock();
-    const errorResponse = {
-      status: 'fail',
-      error: {
-        message: 'Some error occurred while processing your Request',
-        errors: undefined
-      }
-    };
-    sinon.stub(CommentService, 'createComment').throws();
-    await CommentController.create(req, res);
-    expect(res.status).to.have.been.calledWith(500);
-    expect(res.json).to.have.been.calledWith(errorResponse);
+  describe('DELETE /comment/:commentId', () => {
+    it('should prevent an unautheticated user from deleting a comment', async () => {
+      const response = await chai
+        .request(server)
+        .delete(`/api/comment/${commentId}`);
+      expect(response).to.have.status(401);
+      expect(response.body.error.message).to.be.eql('Access denied, Token required');
+    });
+    it('should prevent an unauthorized user from deleting a comment', async () => {
+      const response = await chai
+        .request(server)
+        .delete(`/api/comment/${commentId}`)
+        .set('Cookie', `token=${wrongUserToken}`);
+      expect(response).to.have.status(403);
+      expect(response.body.error.message).to.eql('You are an not authorized to delete this comment');
+    });
+    it('should return a 500 error response if something goes wrong while deleting the comment', async () => {
+      const req = { params: { commentId: 16 } };
+      const mock = () => {
+        const res = {};
+        res.status = sinon.stub().returns(res);
+        res.json = sinon.stub().returns(res);
+        return res;
+      };
+      const res = mock();
+      const errorResponse = {
+        status: 'fail',
+        error: {
+          message: 'Some error occurred while processing your Request',
+          errors: undefined
+        }
+      };
+      sinon.stub(CommentService, 'deleteCommentById').throws();
+      await CommentController.deleteComment(req, res);
+      expect(res.status).to.have.been.calledWith(500);
+      expect(res.json).to.have.been.calledWith(errorResponse);
+    });
+    it('should successfully delete a comment', async () => {
+      const response = await chai
+        .request(server)
+        .delete(`/api/comment/${commentId}`)
+        .set('Cookie', `token=${user.token}`);
+      expect(response).to.have.status(200);
+      expect(response.body.data.id).to.eql(commentId);
+    });
+    it('should return a 404 error if comment to be deleted no longer exists', async () => {
+      const response = await chai
+        .request(server)
+        .delete(`/api/comment/${commentId}`)
+        .set('Cookie', `token=${user.token}`);
+      expect(response).to.have.status(404);
+      expect(response.body.error.message).to.eql(`comment with the id: ${commentId} doesn't exist`);
+    });
   });
 });

--- a/src/test/request.test.js
+++ b/src/test/request.test.js
@@ -23,6 +23,8 @@ describe('Request route endpoints', () => {
   let userToken;
   let userId;
   let companyAdminResponse;
+  let requester;
+  let adminId;
   before(async () => {
     const reqCompany = { body: { ...companyAdmin, email: 'baystef@slack.com', companyName: 'paystack' } };
 
@@ -39,7 +41,7 @@ describe('Request route endpoints', () => {
     };
 
     companyAdminResponse = await companySignUp(reqCompany, res);
-    const { data: { signupToken } } = companyAdminResponse;
+    const { data: { signupToken, admin } } = companyAdminResponse;
     const reqUser = {
       body: {
         ...newCompanyUser, email: 'steve@google.com', signupToken, roleId: 5
@@ -48,6 +50,8 @@ describe('Request route endpoints', () => {
     const companyUserResponse = await userSignup(reqUser, res);
     userToken = companyUserResponse.data.token;
     userId = companyUserResponse.data.id;
+    requester = companyUserResponse.data;
+    adminId = admin.id;
   });
   afterEach(() => {
     sinon.restore();
@@ -75,7 +79,7 @@ describe('Request route endpoints', () => {
       expect(res.status).to.have.been.calledWith(500);
     });
     it('should get a request successfuly', async () => {
-      await Request.create({ ...newRequest, requesterId: userId });
+      await Request.create({ ...newRequest, requesterId: requester.id, managerId: adminId });
       const response = await chai.request(server).get('/api/users/requests').set('Cookie', `token=${userToken}`);
       expect(response).to.have.status(200);
       expect(response.body.status).to.equal('success');
@@ -86,7 +90,7 @@ describe('Request route endpoints', () => {
     it('should successfully create a one-way trip request', async () => {
       const response = await chai
         .request(server).post('/api/trip/request').set('Cookie', `token=${userToken};`)
-        .send(tripRequest);
+        .send({ ...tripRequest, managerId: adminId });
       expect(response).to.have.status(201);
       expect(response.body.data).to.include({
         purpose: 'Official',

--- a/src/validation/tripRequestValidation.js
+++ b/src/validation/tripRequestValidation.js
@@ -122,6 +122,22 @@ export default class TripRequestValidation {
             }
           });
           return errors;
+        }),
+      managerId: Joi.number()
+        .required().error((errors) => {
+          errors.forEach((err) => {
+            switch (err.type) {
+              case 'any.required':
+                err.message = 'managerId is required';
+                break;
+              case 'number.base':
+                err.message = 'managerId must be a number';
+                break;
+              default:
+                break;
+            }
+          });
+          return errors;
         })
     };
     const { error } = Joi.validate({ ...tripObject }, schema);

--- a/swagger.json
+++ b/swagger.json
@@ -781,12 +781,70 @@
                         "description": "Non-existent record"
                       },
                       "500": {
-                        "description": "Internal Server error"
+                        "description": "Internal Server Error"
                       }
                 }
             }
+        },
+        "/comment/{commentId}":{
+            "delete" : {
+                "description": "Deletes a comment from a comment thread",
+                "summary": "Enables a user to delete his/her comment on a travel request",
+                "tags": [
+                    "Comment"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "commentId",
+                        "required": true,
+                        "description": "The ID of the comment you want to delete"
+                    }
+                  ],
+                  "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/requestBody/commentDeleteSuccess"
+                          }
+                    },
+                    "401": {
+                      "description": "Unauthenticated Request",
+                      "schema": {
+                        "$ref": "#/requestBody/401"
+                      }
+                    },
+                    "403": {
+                        "description": "Unauthorized Request",
+                        "schema": {
+                            "$ref": "#/requestBody/403"
+                          }
+                    },
+                    "404": {
+                        "description": "Non-existent record",
+                        "schema": {
+                            "$ref": "#/requestBody/404"
+                          }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/requestBody/500"
+                          }
+                    }
+                }
+            }
         }
-    },
+    }
+    ,
         "requestBody": {
             "userSignupRequest": {
                 "title": "User Signup Request",
@@ -921,7 +979,7 @@
                     "phoneNumber": "08063345598"
                   },
                 "required": [
-                    "firstName, lastName, email, companyName, companyAddress, categoryOfService, password"
+                    "firstName", "lastName", "email", "companyName", "companyAddress", "categoryOfService", "password"
                 ]
             },
             "tripRequest": {
@@ -947,6 +1005,10 @@
                     "departureDate": {
                         "description": "departureDate of trip request",
                         "type": "string"
+                    },
+                    "managerId": {
+                        "description": "The id of the line manager that would process the trip request",
+                        "type": "number"
                     }
                 },
                 "example": {
@@ -954,10 +1016,11 @@
                     "purpose": "official",
                     "origin": "Abuja",
                     "destination": "Lagos",
-                    "departureDate": "2019-11-07"
+                    "departureDate": "2019-11-07",
+                    "managerId": 2
                   },
                 "required": [
-                    "tripType, purpose, origin, destination, departureDate"
+                    "tripType, purpose, origin, destination, departureDate, managerId"
                 ]
             },
             "companySignUpRequest": {
@@ -1352,6 +1415,24 @@
                     }
                 }
               },
+              "commentDeleteSuccess": {
+                  "properties":{
+                    "status" : {
+                        "description":"A success text that indicates the comment has been deleted",
+                        "type": "string"
+                    },
+                    "data": {
+                        "description": "An object that only contains an id property whose value is the id of the deleted comment",
+                        "type": "object"
+                    }
+                  },
+                  "example": {
+                      "status": "success",
+                      "data":{
+                          "id": 2
+                      }
+                  }
+              },
               "400": {
                 "properties": {
                     "status": {
@@ -1385,6 +1466,24 @@
                     "status": "fail",
                     "error": {
                         "message": "Token is required"
+                    }
+                }
+            },
+            "403": {
+                "properties": {
+                    "status": {
+                        "description": "Usually just the text fail",
+                        "type":"string"
+                    },
+                    "error": {
+                        "description": "A descriptive error message",
+                        "type": "object"
+                    }
+                },
+                "example": {
+                    "status": "fail",
+                    "error": {
+                        "message": "User is unauthorized"
                     }
                 }
             },


### PR DESCRIPTION
#### What does this PR do?
Enable users to be able to delete their comments on Travel requests.

#### Description of Task to be completed?
- Create route, service method and controller method that enables a user to delete a comment.
- Add the authorization and authentication middlewares.
- Write unit tests for this feature.
- Document the new endpoint on swagger
#### How should this be manually tested?
- Clone the repo and cd into the apps working directory
- Checkout to the **ft-delete-request-comments-167733663** branch
- Create a .env file and specify the variables described in the .env.sample inside this file.
- Run `npm run migrate:reset` && `npm run migrate` && `npm run seed` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run docker-compose up --build to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`
- Launch Postman/insomnia and signup/login as a new company user. Refer to the swagger document.
- Make a travel request using the appropriate endpoint as documented on the swagger document.
- Make a DELETE request to `localhost:3000/api/comment/:commentId` route where `commentId` refers to the id of the comment to be deleted.
- To run the unit tests, run `npm run test`.
#### Any background context you want to provide?
This application is bootstrapped using docker as described above, however, the app can still be run locally without docker using the `npm run start:dev` 

#### What are the relevant pivotal tracker stories?
[pivotal tracker story](https://www.pivotaltracker.com/story/show/167733663)